### PR TITLE
02 mariko profile edit

### DIFF
--- a/app/controllers/api/v1/profiles_controller.rb
+++ b/app/controllers/api/v1/profiles_controller.rb
@@ -1,8 +1,35 @@
 class Api::V1::ProfilesController < ApplicationController
   before_action :authenticate_api_v1_user!
-  
+  before_action :set_profile, only: %i[show edit update]
+
   def index
     @profiles = Profile.all.includes(:user)
     render json: @profiles
+  end
+
+  def show
+    render json: @profile
+  end
+
+  def edit
+    render json: @profile
+  end
+
+  def update
+    if @profile.update(profile_params)
+      render json: @profile
+    else
+      render json: @profile.errors, status: :bad_request
+    end
+  end
+
+  private
+
+  def set_profile
+    @profile = Profile.find_by(user_id: current_api_v1_user.id)
+  end
+
+  def profile_params
+    params.require(:profile).permit(:times_link, :commitment, :position, :motivation, :self_introduction, :phase, :grade, :editor)
   end
 end

--- a/app/controllers/api/v1/profiles_controller.rb
+++ b/app/controllers/api/v1/profiles_controller.rb
@@ -1,0 +1,8 @@
+class Api::V1::ProfilesController < ApplicationController
+  before_action :authenticate_api_v1_user!
+  
+  def index
+    @profiles = Profile.all.includes(:user)
+    render json: @profiles
+  end
+end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -1,0 +1,29 @@
+# == Schema Information
+#
+# Table name: profiles
+#
+#  id                :integer          not null, primary key
+#  commitment        :string           not null
+#  editor            :string
+#  grade             :integer          not null
+#  motivation        :string           not null
+#  phase             :string           not null
+#  position          :string           not null
+#  self_introduction :text
+#  times_link        :string
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  user_id           :integer          not null
+#
+# Indexes
+#
+#  index_profiles_on_user_id                 (user_id)
+#  index_profiles_on_user_id_and_times_link  (user_id,times_link) UNIQUE
+#
+# Foreign Keys
+#
+#  user_id  (user_id => users.id)
+#
+class Profile < ApplicationRecord
+  belongs_to :user
+end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -29,12 +29,6 @@ class Profile < ApplicationRecord
 
   validates :times_link, length: { maximum: 100 },
                          format: { with: /\A(https\:\/\/chat\.runteq\.jp\/runteq\/channels\/)+([A-Za-z0-9_]*)/ }
-  validates :commitment
-  validates :position
-  validates :motivation
   validates :self_introduction, length: { maximum: 100 }
-  validates :phase
-  validates :grade
-  validates :editor
   validates :user_id, presence: true
 end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -26,4 +26,15 @@
 #
 class Profile < ApplicationRecord
   belongs_to :user
+
+  validates :times_link, length: { maximum: 100 },
+                         format: { with: /\A(https\:\/\/chat\.runteq\.jp\/runteq\/channels) }
+  validates :commitment, presence: true
+  validates :position, presence: true
+  validates :motivation, presence: true
+  validates :self_introduction, length: { maximum: 100 }
+  validates :phase, presence: true
+  validates :grade, presence: true
+  validates :editor
+  validates :user_id, presence: true
 end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -28,7 +28,8 @@ class Profile < ApplicationRecord
   belongs_to :user
 
   validates :times_link, length: { maximum: 100 },
-                         format: { with: /\A(https\:\/\/chat\.runteq\.jp\/runteq\/channels\/)+([A-Za-z0-9_]*)/ }
+                         format: { with: /\A(https\:\/\/chat\.runteq\.jp\/runteq\/channels\/)+([A-Za-z0-9_]*)/ },
+                         allow_nil: true
   validates :self_introduction, length: { maximum: 100 }
   validates :user_id, presence: true
 end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -27,9 +27,7 @@
 class Profile < ApplicationRecord
   belongs_to :user
 
-  validates :times_link, length: { maximum: 100 },
-                         format: { with: /\A(https\:\/\/chat\.runteq\.jp\/runteq\/channels\/)+([A-Za-z0-9_]*)/ },
-                         allow_nil: true
+  validates :times_link, length: { maximum: 50 }
   validates :self_introduction, length: { maximum: 100 }
   validates :user_id, presence: true
 end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -3,12 +3,12 @@
 # Table name: profiles
 #
 #  id                :integer          not null, primary key
-#  commitment        :string           not null
+#  commitment        :string
 #  editor            :string
-#  grade             :integer          not null
-#  motivation        :string           not null
-#  phase             :string           not null
-#  position          :string           not null
+#  grade             :integer
+#  motivation        :string
+#  phase             :string
+#  position          :string
 #  self_introduction :text
 #  times_link        :string
 #  created_at        :datetime         not null
@@ -28,13 +28,13 @@ class Profile < ApplicationRecord
   belongs_to :user
 
   validates :times_link, length: { maximum: 100 },
-                         format: { with: /\A(https\:\/\/chat\.runteq\.jp\/runteq\/channels) }
-  validates :commitment, presence: true
-  validates :position, presence: true
-  validates :motivation, presence: true
+                         format: { with: /\A(https\:\/\/chat\.runteq\.jp\/runteq\/channels\/)+([A-Za-z0-9_]*)/ }
+  validates :commitment
+  validates :position
+  validates :motivation
   validates :self_introduction, length: { maximum: 100 }
-  validates :phase, presence: true
-  validates :grade, presence: true
+  validates :phase
+  validates :grade
   validates :editor
   validates :user_id, presence: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -24,5 +24,7 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable, :omniauthable
   include DeviseTokenAuth::Concerns::User
+
+  has_one :profile, dependent: :destroy
   validates :uid, presence: true, uniqueness: { scope: :provider }
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,8 @@ Rails.application.routes.draw do
       mount_devise_token_auth_for 'User', at: 'auth', controllers: {
         omniauth_callback: 'overrides/omniauth_callback'
       }
+
+      resources :profiles, only: %i[index]
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,7 @@ Rails.application.routes.draw do
         omniauth_callback: 'overrides/omniauth_callback'
       }
 
-      resources :profiles, only: %i[index]
+      resources :profiles, only: %i[index show edit update]
     end
   end
 end

--- a/db/migrate/20221123013719_create_profiles.rb
+++ b/db/migrate/20221123013719_create_profiles.rb
@@ -1,0 +1,19 @@
+class CreateProfiles < ActiveRecord::Migration[6.1]
+  def change
+    create_table :profiles do |t|
+      t.string :times_link
+      t.string :commitment, null: false
+      t.string :position, null: false
+      t.string :motivation, null: false
+      t.text :self_introduction
+      t.string :phase, null: false
+      t.integer :grade, null: false
+      t.string :editor
+      t.references :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+
+    add_index :profiles, [:user_id, :times_link], unique: true
+  end
+end

--- a/db/migrate/20221123040006_change_not_null_to_profile.rb
+++ b/db/migrate/20221123040006_change_not_null_to_profile.rb
@@ -1,0 +1,17 @@
+class ChangeNotNullToProfile < ActiveRecord::Migration[6.1]
+  def up
+    change_column_null :profiles, :commitment, true
+    change_column_null :profiles, :position, true
+    change_column_null :profiles, :motivation, true
+    change_column_null :profiles, :phase, true
+    change_column_null :profiles, :grade, true
+  end
+
+  def down
+    change_column_null :profiles, :commitment, false
+    change_column_null :profiles, :position, false
+    change_column_null :profiles, :motivation, false
+    change_column_null :profiles, :phase, false
+    change_column_null :profiles, :grade, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,16 +10,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_11_23_013719) do
+ActiveRecord::Schema.define(version: 2022_11_23_040006) do
 
   create_table "profiles", force: :cascade do |t|
     t.string "times_link"
-    t.string "commitment", null: false
-    t.string "position", null: false
-    t.string "motivation", null: false
+    t.string "commitment"
+    t.string "position"
+    t.string "motivation"
     t.text "self_introduction"
-    t.string "phase", null: false
-    t.integer "grade", null: false
+    t.string "phase"
+    t.integer "grade"
     t.string "editor"
     t.integer "user_id", null: false
     t.datetime "created_at", precision: 6, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,23 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_11_17_130440) do
+ActiveRecord::Schema.define(version: 2022_11_23_013719) do
+
+  create_table "profiles", force: :cascade do |t|
+    t.string "times_link"
+    t.string "commitment", null: false
+    t.string "position", null: false
+    t.string "motivation", null: false
+    t.text "self_introduction"
+    t.string "phase", null: false
+    t.integer "grade", null: false
+    t.string "editor"
+    t.integer "user_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_id", "times_link"], name: "index_profiles_on_user_id_and_times_link", unique: true
+    t.index ["user_id"], name: "index_profiles_on_user_id"
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "provider", default: "email", null: false
@@ -26,4 +42,5 @@ ActiveRecord::Schema.define(version: 2022_11_17_130440) do
     t.index ["uid", "provider"], name: "index_users_on_uid_and_provider", unique: true
   end
 
+  add_foreign_key "profiles", "users"
 end


### PR DESCRIPTION
# Issue
close #6

# やったこと
- Profileモデル作成し、バリデーション追加
- UserモデルとProfileモデルのアソシエーション定義
- マイグレーションファイルに制約
- profilesコントローラで`index`, `show`, `edit`, `update`アクションを定義
- 上記のアクションをルーティング追加

# 動作確認
`Rails console`でユーザーに紐づいたプロフィールを作成し、`index`, `show`, `edit`アクションが正しく動作していることを確認

# その他
- 現状profilesテーブルのカラムは`user_id`以外全てnullを許可しています。
- Vue側と連携して確認する方法がわからなかったので、確認できているのは一旦ルーティング定義したうちの`index`, `show`, `edit`アクション（GET)のみです。
- 確認時は認証エラーが出ているのでprofilesコントローラの`before_action :authenticate_api_v1_user!`を一旦削除し、
```
def set_profile
    @profile = Profile.find_by(user_id: current_api_v1_user.id)
 end
```
上のコードの`user_id: current_api_v1_user.id`の箇所を`user_id: 1`で試しました。
