### PR TITLE
03 mariko modify profile controller

### DIFF
--- a/app/controllers/api/v1/profiles_controller.rb
+++ b/app/controllers/api/v1/profiles_controller.rb
@@ -8,6 +8,7 @@ class Api::V1::ProfilesController < ApplicationController
   end
 
   def show
+    @profile ||= Profile.create!(user_id: current_api_v1_user.id)
     render json: @profile
   end
 

--- a/app/controllers/api/v1/profiles_controller.rb
+++ b/app/controllers/api/v1/profiles_controller.rb
@@ -1,6 +1,6 @@
 class Api::V1::ProfilesController < ApplicationController
   before_action :authenticate_api_v1_user!
-  before_action :set_profile, only: %i[show edit update]
+  before_action :set_profile, only: %i[show update]
 
   def index
     @profiles = Profile.all.includes(:user)
@@ -9,10 +9,6 @@ class Api::V1::ProfilesController < ApplicationController
 
   def show
     @profile ||= Profile.create!(user_id: current_api_v1_user.id)
-    render json: @profile
-  end
-
-  def edit
     render json: @profile
   end
 


### PR DESCRIPTION
# Issue
#6

# やったこと
プロフィールコントローラーのエンドポイントを2つに集約
- プロフィールを編集するボタンを押した時に実行される処理を`show`アクションで定義
  - 新規作成時、Profileの空のオブジェクトを作成
  - 作成済みの時、ユーザーのプロフィールを取得
- プロフィール編集を登録する時に実行される処理を`update`アクションで定義
  - プロフィールの編集

# 動作確認
`current_api_v1_user.id`だとエラーが発生したため、
`user_id: 1`のユーザーが作成されている状態で`user_id: current_api_v1_user.id`の箇所を`user_id: 1`で確認しました。
プロフィール作成されていない場合は空のオブジェクトを新規作成、作成済みの場合はユーザーのプロフィールを取得できることを確認

# その他
関連するプルリクエスト（マージ済み　#14）
