### PR TITLE
Fix:ユーザー一覧でアイコン画像とユーザー名を取得できるよう変更

### DIFF
--- a/app/controllers/api/v1/profiles_controller.rb
+++ b/app/controllers/api/v1/profiles_controller.rb
@@ -4,7 +4,10 @@ class Api::V1::ProfilesController < ApplicationController
 
   def index
     @profiles = Profile.all.includes(:user)
-    render json: @profiles
+    @user_profiles = @profiles.map do |profile|
+      [profile: profile, name: profile.user.name, image: profile.user.image]
+    end
+    render json: @user_profiles
   end
 
   def show

--- a/app/controllers/api/v1/profiles_controller.rb
+++ b/app/controllers/api/v1/profiles_controller.rb
@@ -5,7 +5,7 @@ class Api::V1::ProfilesController < ApplicationController
   def index
     @profiles = Profile.all.includes(:user)
     @user_profiles = @profiles.map do |profile|
-      [profile: profile, name: profile.user.name, image: profile.user.image]
+      {profile: profile, name: profile.user.name, image: profile.user.image}
     end
     render json: @user_profiles
   end


### PR DESCRIPTION
# やったこと
- profilesコントローラのindexアクションでユーザー一覧取得時にプロフィール項目に合わせてユーザー名とユーザーアイコンを取得できるよう修正

# 動作確認
`before_action :authenticate_api_v1_user!`を一旦消して`http://localhost:3000/api/v1/profiles`にアクセスしてJSONデータで取得できていることを確認

# その他
データ取得はできていそうだがこの形式で良いのか確認したい
