### PR TITLE
06 mariko pagination

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,3 +65,5 @@ gem 'rack-cors'
 gem 'net-smtp'
 gem 'net-imap'
 gem 'net-pop'
+
+gem 'kaminari'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -108,6 +108,18 @@ GEM
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     jwt (2.5.0)
+    kaminari (1.2.2)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.2)
+      kaminari-activerecord (= 1.2.2)
+      kaminari-core (= 1.2.2)
+    kaminari-actionview (1.2.2)
+      actionview
+      kaminari-core (= 1.2.2)
+    kaminari-activerecord (1.2.2)
+      activerecord
+      kaminari-core (= 1.2.2)
+    kaminari-core (1.2.2)
     listen (3.7.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -279,6 +291,7 @@ DEPENDENCIES
   devise_token_auth!
   dotenv-rails
   faker
+  kaminari
   listen (~> 3.3)
   net-imap
   net-pop

--- a/app/controllers/api/v1/profiles_controller.rb
+++ b/app/controllers/api/v1/profiles_controller.rb
@@ -3,14 +3,14 @@ class Api::V1::ProfilesController < ApplicationController
   before_action :set_profile, only: %i[show update]
 
   def index
-    @profiles = Profile.all.includes(:user)
-    @user_profiles = @profiles.map do |profile|
+    profiles = Profile.all.includes(:user)
+    user_profiles = profiles.map do |profile|
       {profile: profile, name: profile.user.name, image: profile.user.image}
     end
 
     page = params[:page] || 1
     per = params[:per] || 10
-    view_profiles = Kaminari.paginate_array(@user_profiles).page(page).per(per)
+    view_profiles = Kaminari.paginate_array(user_profiles).page(page).per(per)
     total_pages = view_profiles.total_pages
 
     response = {

--- a/app/controllers/api/v1/profiles_controller.rb
+++ b/app/controllers/api/v1/profiles_controller.rb
@@ -7,7 +7,17 @@ class Api::V1::ProfilesController < ApplicationController
     @user_profiles = @profiles.map do |profile|
       {profile: profile, name: profile.user.name, image: profile.user.image}
     end
-    render json: @user_profiles
+
+    page = params[:page] || 1
+    per = params[:per] || 10
+    view_profiles = Kaminari.paginate_array(@user_profiles).page(page).per(per)
+    total_pages = view_profiles.total_pages
+
+    response = {
+      profiles: view_profiles,
+      total_pages: total_pages
+    }
+    render json: response
   end
 
   def show


### PR DESCRIPTION
# Issue
close #35

# やったこと
- gem`kaminari`追加
- profilesコントローラの`index`アクションでプロフィールの件数を指定したレスポンスを返す
（ひとまず記事参考に1ページあたり10件にしています）
- 不要なインスタンス変数記載を修正

# 動作確認
`before_action :authenticate_api_v1_user!`をコメントアウトして`http://localhost:3000/api/v1/profiles`にアクセスした際に10件表示されることを確認
[![Image from Gyazo](https://i.gyazo.com/a6aba5d0c7450540902777c8255989b8.jpg)](https://gyazo.com/a6aba5d0c7450540902777c8255989b8)

# その他
共有いただいた記事参考にしました。
https://qiita.com/iPzYN2gLSV2HeSS/items/0dbd4d23baf36f9fc06f
