### PR TITLE
07 mariko GitHub username

### DIFF
--- a/app/controllers/api/v1/auth/omniauth_callbacks_controller.rb
+++ b/app/controllers/api/v1/auth/omniauth_callbacks_controller.rb
@@ -11,6 +11,7 @@ skip_before_action :skip_session
     when 'github'
       user.assign_attributes({
                                name: auth_hash['info']['name'],
+                               username: auth_hash['info']['nickname'],
                                image: auth_hash['info']['image'],
                                email: auth_hash['info']['email']
                              })

--- a/app/controllers/api/v1/profiles_controller.rb
+++ b/app/controllers/api/v1/profiles_controller.rb
@@ -1,11 +1,12 @@
 class Api::V1::ProfilesController < ApplicationController
-  before_action :authenticate_api_v1_user!
+  # before_action :authenticate_api_v1_user!
   before_action :set_profile, only: %i[show update]
 
   def index
+    binding.pry
     profiles = Profile.all.includes(:user)
     user_profiles = profiles.map do |profile|
-      {profile: profile, name: profile.user.name, image: profile.user.image}
+      {profile: profile, name: profile.user.name, username: profile.user.username, image: profile.user.image}
     end
 
     page = params[:page] || 1

--- a/app/controllers/api/v1/profiles_controller.rb
+++ b/app/controllers/api/v1/profiles_controller.rb
@@ -1,9 +1,8 @@
 class Api::V1::ProfilesController < ApplicationController
-  # before_action :authenticate_api_v1_user!
+  before_action :authenticate_api_v1_user!
   before_action :set_profile, only: %i[show update]
 
   def index
-    binding.pry
     profiles = Profile.all.includes(:user)
     user_profiles = profiles.map do |profile|
       {profile: profile, name: profile.user.name, username: profile.user.username, image: profile.user.image}

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -1,3 +1,29 @@
+# == Schema Information
+#
+# Table name: profiles
+#
+#  id                :integer          not null, primary key
+#  commitment        :string
+#  editor            :string
+#  grade             :integer
+#  motivation        :string
+#  phase             :string
+#  position          :string
+#  self_introduction :text
+#  times_link        :string
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  user_id           :integer          not null
+#
+# Indexes
+#
+#  index_profiles_on_user_id                 (user_id)
+#  index_profiles_on_user_id_and_times_link  (user_id,times_link) UNIQUE
+#
+# Foreign Keys
+#
+#  user_id  (user_id => users.id)
+#
 class Profile < ApplicationRecord
   belongs_to :user
   has_many :profile_tags, dependent: :destroy

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,6 +10,7 @@
 #  provider           :string           default("email"), not null
 #  tokens             :json
 #  uid                :string           default(""), not null
+#  username           :string
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
 #

--- a/db/migrate/20230114012107_add_username_to_users.rb
+++ b/db/migrate/20230114012107_add_username_to_users.rb
@@ -1,0 +1,5 @@
+class AddUsernameToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :username, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_12_13_100851) do
+ActiveRecord::Schema.define(version: 2023_01_14_012107) do
 
   create_table "profile_tags", force: :cascade do |t|
     t.integer "profile_id", null: false
@@ -54,6 +54,7 @@ ActiveRecord::Schema.define(version: 2022_12_13_100851) do
     t.json "tokens"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "username"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["uid", "provider"], name: "index_users_on_uid_and_provider", unique: true
   end


### PR DESCRIPTION
# Issue
close #36

# やったこと
- usersテーブルに`username`カラム追加
- GitHubログイン時に`username`も登録できるよう変更

# 動作確認
一度アプリとのGitHub連携を解除してから新たにGitHubログイン、コンソールでユーザー情報を確認したら`username`を取得できていることを確認
```
[1] pry(main)> user=User.find(61)
   (0.7ms)  SELECT sqlite_version(*)
  User Load (0.5ms)  SELECT "users".* FROM "users" WHERE "users"."id" = ? LIMIT ?  [["id", 61], ["LIMIT", 1]]
=> #<User id: 61, provider: "github", uid: "95598364", name: "Mariko", image: "https://avatars.githubusercontent.com/u/95598364?v...", email: nil, created_at: "2023-01-14 01:13:55.851573000 +0000", updated_at: "2023-01-14 01:37:12.218324000 +0000", username: "Mariko222">
```

# その他
プロフィール一覧で確認できる名前は元の`name`のままにしています。
```
def index
    profiles = Profile.all.includes(:user)
    user_profiles = profiles.map do |profile|
      {profile: profile, name: profile.user.name, image: profile.user.image}
    end
（略）
```